### PR TITLE
Semgentation Fault Caused by Inadequate MEM_SIZE

### DIFF
--- a/config/config.h
+++ b/config/config.h
@@ -56,7 +56,9 @@ bool checkFault (unsigned int, unsigned int, unsigned int, int, unsigned int);
 
 
 //#define MEM_SIZE	1024//0xe000000
-#define MEM_SIZE	0x8000//3800000//1024//0xe000000
+//#define MEM_SIZE	0x8000//3800000//1024//0xe000000
+#define MEM_SIZE	0x4000//3800000//1024//0xe000000
+//#define MEM_SIZE	MEM_index_end
 //unsigned int MEM[MEM_SIZE];
 //unsigned char MEM0[MEM_SIZE];
 //unsigned char MEM1[MEM_SIZE];


### PR DESCRIPTION
This bug is due to MEM_SIZE which was larger than the size of MEM.
 The fault has been fixed by this commit.
